### PR TITLE
Fix MathJax display math rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,6 @@ plugins:
   - jekyll-seo-tag
 
 markdown: kramdown
+kramdown:
+  input: GFM
+  math_engine: mathjax

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
       window.MathJax = {
         tex: {
           inlineMath: [['$', '$'], ['\\(', '\\)']],
-          displayMath: [['$$','$$']],
+          displayMath: [['$$','$$'], ['\\[', '\\]']],
           processEscapes: true
         },
         options: {


### PR DESCRIPTION
## Summary
- add MathJax display delimiters so `\[ ... \]` formulas render correctly
- configure Kramdown to use MathJax with GFM input for consistent markdown parsing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe8a5caa0832d88f0cd22750f0e1e