### PR TITLE
Add Weglot translation script to site head

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,6 +37,13 @@
       src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
     </script>
 
+    <script type="text/javascript" src="https://cdn.weglot.com/weglot.min.js"></script>
+    <script>
+      Weglot.initialize({
+        api_key: 'wg_17ab5b940b4609b2632793b20d8c98975'
+      });
+    </script>
+
     {% seo %}
   </head>
 


### PR DESCRIPTION
### Motivation
- Load Weglot on every page by injecting the Weglot loader and initialization so the site can offer translations globally.

### Description
- Inserted the Weglot loader `<script src="https://cdn.weglot.com/weglot.min.js"></script>` and a `Weglot.initialize({ api_key: 'wg_17ab5b940b4609b2632793b20d8c98975' })` snippet into the head of the site layout file `/_layouts/default.html` just before the `</head>` (ahead of the `{% seo %}` tag).